### PR TITLE
fix specs, because the original Gemfile.lock has never been committed or pushed (got ignored in .gitignore)

### DIFF
--- a/spec/dependency_spec.rb
+++ b/spec/dependency_spec.rb
@@ -5,12 +5,12 @@ module GemVersionCheck
   describe Dependency do
 
     context "#check" do
-      let(:lock_file) { Lockfile.new(lock_file_content("Gemfile.lock")) }
+      let(:lock_file) { Lockfile.new(lock_file_content("rails_app_example.lock")) }
 
-      let(:dependency) { Dependency.new("activesupport", "3.2.9") }
-      let(:invalid_dependency) { Dependency.new("activesupport", "3.2.10") }
-      let(:not_used_dependency) { Dependency.new("rails", "3.2.9") }
-      
+      let(:dependency) { Dependency.new("activesupport", "3.2.8") }
+      let(:invalid_dependency) { Dependency.new("activesupport", "3.2.9") }
+      let(:not_used_dependency) { Dependency.new("exceptionist", "3.2.8") }
+
       context "#valid?" do
         it "is valid if current version == expected version" do
           dependency.check(lock_file)
@@ -42,7 +42,7 @@ module GemVersionCheck
         end
 
         it "returns true if gem was not found on gems server" do
-          dep = Dependency.new("non_existing_gem") 
+          dep = Dependency.new("non_existing_gem")
           dep.expects(:retrieve_spec).returns(nil)
           dep.check(lock_file)
 

--- a/spec/lockfile_fetch_spec.rb
+++ b/spec/lockfile_fetch_spec.rb
@@ -21,7 +21,7 @@ module GemVersionCheck
     context "#lock_file" do
       it "downloads lock file content and returns lock_file" do
         fetcher = LockfileFetcher.new(redirect_url)
-        fetcher.expects(:request).returns(lock_file_content("Gemfile.lock"))
+        fetcher.expects(:request).returns(lock_file_content("rails_app_example.lock"))
         Bundler::LockfileParser.new(fetcher.content).specs.size.should > 0
       end
 

--- a/spec/lockfile_spec.rb
+++ b/spec/lockfile_spec.rb
@@ -3,18 +3,18 @@ require 'spec_helper'
 
 module GemVersionCheck
   describe Lockfile do
-    let(:lockfile) { Lockfile.new(lock_file_content("Gemfile.lock")) }
+    let(:lockfile) { Lockfile.new(lock_file_content("rails_app_example.lock")) }
 
     describe "#spec_names" do
       it "returns all spec names" do
-        lockfile.spec_names.size.should == 12
+        lockfile.spec_names.size.should == 47
         lockfile.spec_names.should include("activesupport")
       end
     end
 
     describe "#version_for" do
       it "returns spec for name" do
-        lockfile.version_for("activesupport").should == "3.2.9"
+        lockfile.version_for("activesupport").should == "3.2.8"
       end
 
       it "returns nil if spec does not exist" do
@@ -24,7 +24,7 @@ module GemVersionCheck
 
     describe "#total" do
       it "returns total number of spec" do
-        lockfile.total.should == 12
+        lockfile.total.should == 47
       end
     end
   end


### PR DESCRIPTION
fix specs, because the original Gemfile.lock has never been committed or pushed (got ignored in .gitignore)
