### PR TITLE
Project check should not fail for unused dependencies

### DIFF
--- a/lib/gem_version_check/project.rb
+++ b/lib/gem_version_check/project.rb
@@ -27,7 +27,7 @@ module GemVersionCheck
         dependency.check(lock_file)
         result << dependency
 
-        @check_failed = true unless dependency.valid?
+        @check_failed = true if dependency.used? && !dependency.valid?
       end
       result
     end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -65,6 +65,15 @@ module GemVersionCheck
       context "without black- or whitelisting" do
         include_examples "check_failed"
       end
+
+      context "with unused gems" do
+        let(:options) { { only: %w(redis) } }
+
+        it "returns false if all used dependecies are up to date" do
+          project.check_failed?.should == false
+        end
+      end
+
     end
   end
 end

--- a/spec/project_spec.rb
+++ b/spec/project_spec.rb
@@ -43,18 +43,22 @@ module GemVersionCheck
 
     shared_examples "check_failed" do
       it "returns true if at least one dependency is not up to date or non existing" do
-        project.check_failed? == true
+        project.check_failed?.should == true
       end
     end
 
     context "#check_failed?" do
+      before do
+        project.generate_report
+      end
+
       context "with whitelisted gems" do
-        let(:options) { { only: "actionpack" } }
+        let(:options) { { only: %w(actionpack) } }
         include_examples "check_failed"
       end
 
       context "with blacklisted gems" do
-        let(:options) { { except: "actionpack" } }
+        let(:options) { { except: %w(actionpack) } }
         include_examples "check_failed"
       end
 


### PR DESCRIPTION
If given as only/except parameters, the project dependencies
might include entries, which are not even used by the
project. These dependencies are already correctly printed by
the report as not being used, but also mark the whole project check as failed.

I also fixed parts of the tests, which could never fail, because of a missing expectation.